### PR TITLE
Fixed retrieving C.CURLINFO_SLIST type in Getinfo function

### DIFF
--- a/easy.go
+++ b/easy.go
@@ -31,7 +31,7 @@ static CURLcode curl_easy_getinfo_long(CURL *curl, CURLINFO info, long *p) {
 static CURLcode curl_easy_getinfo_double(CURL *curl, CURLINFO info, double *p) {
  return curl_easy_getinfo(curl, info, p);
 }
-static CURLcode curl_easy_getinfo_slist(CURL *curl, CURLINFO info, struct curl_slist *p) {
+static CURLcode curl_easy_getinfo_slist(CURL *curl, CURLINFO info, struct curl_slist **p) {
  return curl_easy_getinfo(curl, info, p);
 }
 
@@ -372,9 +372,9 @@ func (curl *CURL) Getinfo(info CurlInfo) (ret interface{}, err error) {
 		ret := float64(a_double)
 		debugf("Getinfo %s", ret)
 		return ret, err
-	case C.CURLINFO_SLIST: // need fix
+	case C.CURLINFO_SLIST:
 		a_ptr_slist := new(_Ctype_struct_curl_slist)
-		err := newCurlError(C.curl_easy_getinfo_slist(p, cInfo, a_ptr_slist))
+		err := newCurlError(C.curl_easy_getinfo_slist(p, cInfo, &a_ptr_slist))
 		ret := []string{}
 		for a_ptr_slist != nil {
 			debugf("Getinfo %s %v", C.GoString(a_ptr_slist.data), a_ptr_slist.next)


### PR DESCRIPTION
Function curl_easy_getinfo_slist now use pointer of pointer of struct instead of pointer of struct.