### PR TITLE
Pointer size mismatch fix

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -62,10 +62,11 @@ type CURLM struct {
 	handle unsafe.Pointer
 }
 
+var dummy unsafe.Pointer
 type CURLMessage struct {
 	Msg CurlMultiMsg
 	Easy_handle *CURL
-	Data [8]byte
+	Data [unsafe.Sizeof(dummy)]byte
 }
 
 // curl_multi_init - create a multi handle


### PR DESCRIPTION
This change fixes a problem with a mismatch between CURLMessage and C.CURLMsg on systems with 32-bit pointers.
