### PR TITLE
Change the callback interface to comply with cgo pointer rules.

### DIFF
--- a/c-callback.c
+++ b/c-callback.c
@@ -5,13 +5,7 @@
 
 /* for OPT_HEADERFUNCTION */
 size_t header_function( char *ptr, size_t size, size_t nmemb, void *ctx) {
-    void *go_header_func = (void *)goGetCurlField((GoUintptr)ctx, "headerFunction");
-    GoInterface *userdata = (GoInterface *)goGetCurlField((GoUintptr)ctx, "headerData");
-
-    if (userdata == NULL) {
-	return goCallWriteFunctionCallback(go_header_func, ptr, size*nmemb, goNilInterface());
-    }
-    return goCallWriteFunctionCallback(go_header_func, ptr, size*nmemb, *userdata);
+	return goCallHeaderFunction(ptr, size*nmemb, ctx);
 }
 
 void *return_header_function() {
@@ -21,13 +15,7 @@ void *return_header_function() {
 
 /* for OPT_WRITEFUNCTION */
 size_t write_function( char *ptr, size_t size, size_t nmemb, void *ctx) {
-    void *go_write_func = (void *)goGetCurlField((GoUintptr)ctx, "writeFunction");
-    GoInterface *userdata = (GoInterface *)goGetCurlField((GoUintptr)ctx, "writeData");
-
-    if (userdata == NULL) {
-	return goCallWriteFunctionCallback(go_write_func, ptr, size*nmemb, goNilInterface());
-    }
-    return goCallWriteFunctionCallback(go_write_func, ptr, size*nmemb, *userdata);
+	return goCallWriteFunction(ptr, size*nmemb, ctx);
 }
 
 void *return_write_function() {
@@ -36,13 +24,7 @@ void *return_write_function() {
 
 /* for OPT_READFUNCTION */
 size_t read_function( char *ptr, size_t size, size_t nmemb, void *ctx) {
-    void *go_read_func = (void *)goGetCurlField((GoUintptr)ctx, "readFunction");
-    GoInterface *userdata = (GoInterface *)goGetCurlField((GoUintptr)ctx, "readData");
-
-    if (userdata == NULL) {
-	return goCallReadFunctionCallback(go_read_func, ptr, size*nmemb, goNilInterface());
-    }
-    return goCallReadFunctionCallback(go_read_func, ptr, size*nmemb, *userdata);
+	return goCallReadFunction(ptr, size*nmemb, ctx);
 }
 
 void *return_read_function() {
@@ -52,15 +34,7 @@ void *return_read_function() {
 
 /* for OPT_PROGRESSFUNCTION */
 int progress_function(void *ctx, double dltotal, double dlnow, double ultotal, double ulnow) {
-    void *go_progress_func = (void *)goGetCurlField((GoUintptr)ctx, "progressFunction");
-    GoInterface *clientp = (GoInterface *)goGetCurlField((GoUintptr)ctx, "progressData");
-
-    if (clientp == NULL) {
-	return goCallProgressCallback(go_progress_func, goNilInterface(),
-				    dltotal, dlnow, ultotal, ulnow);
-    }
-    return goCallProgressCallback(go_progress_func, *clientp,
-				dltotal, dlnow, ultotal, ulnow);
+	return goCallProgressFunction(dltotal, dlnow, ultotal, ulnow, ctx);
 }
 
 void *return_progress_function() {

--- a/callback.go
+++ b/callback.go
@@ -9,78 +9,45 @@ package curl
 import "C"
 
 import (
-	"reflect"
 	"unsafe"
 )
 
-//export goGetCurlField
-func goGetCurlField(p uintptr, cname *C.char) uintptr {
-	name := C.GoString(cname)
-	curl := (*CURL)(unsafe.Pointer(p))
-	switch name {
-	case "readFunction":
-		return reflect.ValueOf(curl.readFunction).Pointer()
-	case "headerFunction":
-		return reflect.ValueOf(curl.headerFunction).Pointer()
-	case "writeFunction":
-		return reflect.ValueOf(curl.writeFunction).Pointer()
-	case "progressFunction":
-		return reflect.ValueOf(curl.progressFunction).Pointer()
-	case "headerData":
-		return uintptr(unsafe.Pointer(curl.headerData))
-	case "writeData":
-		return uintptr(unsafe.Pointer(curl.writeData))
-	case "readData":
-		return uintptr(unsafe.Pointer(curl.readData))
-	case "progressData":
-		return uintptr(unsafe.Pointer(curl.progressData))
-	}
-
-	warnf("Field not found: %s", name)
-	return 0
-}
-
-//export goNilInterface
-func goNilInterface() interface{} {
-	return nil
-}
-
-// callback functions
-//export goCallWriteFunctionCallback
-func goCallWriteFunctionCallback(f *func([]byte, interface{}) bool,
-	ptr *C.char,
-	size C.size_t,
-	userdata interface{}) uintptr {
+//export goCallHeaderFunction
+func goCallHeaderFunction(ptr *C.char, size C.size_t, ctx unsafe.Pointer) uintptr {
+	curl := (*CURL)(ctx)
 	buf := C.GoBytes(unsafe.Pointer(ptr), C.int(size))
-	ok := (*f)(buf, userdata)
-	if ok {
+	if (*curl.headerFunction)(buf, curl.headerData) {
 		return uintptr(size)
 	}
-	//return uintptr(C.CURL_MAX_WRITE_SIZE + 1)
 	return C.CURL_WRITEFUNC_PAUSE
 }
 
-//export goCallProgressCallback
-func goCallProgressCallback(f *func(float64, float64, float64, float64, interface{}) bool,
-	userdata interface{},
-	dltotal, dlnow, ultotal, ulnow C.double) int {
-	// fdltotal, fdlnow, fultotal, fulnow
-	ok := (*f)(float64(dltotal), float64(dlnow), float64(ultotal), float64(ulnow), userdata)
-	// non-zero va lue will cause libcurl to abort the transfer and return Error
-	if ok {
+//export goCallWriteFunction
+func goCallWriteFunction(ptr *C.char, size C.size_t, ctx unsafe.Pointer) uintptr {
+	curl := context_map[uintptr(ctx)]
+	buf := C.GoBytes(unsafe.Pointer(ptr), C.int(size))
+	if (*curl.writeFunction)(buf, curl.writeData) {
+		return uintptr(size)
+	}
+	return C.CURL_WRITEFUNC_PAUSE
+}
+
+//export goCallProgressFunction
+func goCallProgressFunction(dltotal, dlnow, ultotal, ulnow C.double, ctx unsafe.Pointer) int {
+	curl := context_map[uintptr(ctx)]
+	if (*curl.progressFunction)(float64(dltotal), float64(dlnow),
+		                 float64(ultotal), float64(ulnow),
+		                 curl.progressData) {
 		return 0
 	}
 	return 1
 }
 
-//export goCallReadFunctionCallback
-func goCallReadFunctionCallback(f *func([]byte, interface{}) int,
-	ptr *C.char,
-	size C.size_t,
-	userdata interface{}) uintptr {
-	// TODO code cleanup
+//export goCallReadFunction
+func goCallReadFunction(ptr *C.char, size C.size_t, ctx unsafe.Pointer) uintptr {
+	curl := context_map[uintptr(ctx)]
 	buf := C.GoBytes(unsafe.Pointer(ptr), C.int(size))
-	ret := (*f)(buf, userdata)
+	ret := (*curl.readFunction)(buf, curl.readData)
 	str := C.CString(string(buf))
 	defer C.free(unsafe.Pointer(str))
 	if C.memcpy(unsafe.Pointer(ptr), unsafe.Pointer(str), C.size_t(ret)) == nil {


### PR DESCRIPTION
Rather than resolving go references in the C callback stubs, the C stubs now just pass control to go functions that perform the go-side callbacks.

Fixes #43, and works in the application I've got that is migrating to go 1.6 as well.