### PR TITLE
Update curl context in goCallHeaderFunction to use context_map

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -14,7 +14,7 @@ import (
 
 //export goCallHeaderFunction
 func goCallHeaderFunction(ptr *C.char, size C.size_t, ctx unsafe.Pointer) uintptr {
-	curl := (*CURL)(ctx)
+	curl := context_map[uintptr(ctx)]
 	buf := C.GoBytes(unsafe.Pointer(ptr), C.int(size))
 	if (*curl.headerFunction)(buf, curl.headerData) {
 		return uintptr(size)


### PR DESCRIPTION
Fixes a null pointer dereference in goCallHeaderFunction.

Reproduction:

    easy := curl.EasyInit()
    defer easy.Cleanup()
    easy.Setopt(curl.OPT_URL, "http://google.com")
    easy.Setopt(curl.OPT_HEADERFUNCTION, func (a []byte, b interface{}) bool { return true })
    easy.Perform()