### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -1,6 +1,8 @@
 package curl
 
 /*
+#cgo freebsd CFLAGS: -I/usr/local/include
+#cgo freebsd LDFLAGS: -L/usr/local/lib -lcurl
 #include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>


### PR DESCRIPTION
On FreeBSD non-system libraries and headers typically installed into `/usr/local` prefix, which is not used by compiler by default, and have to be optionally specified.