### PR TITLE
easy.go: update identifier to C.struct_curl_slist

### DIFF
--- a/easy.go
+++ b/easy.go
@@ -405,7 +405,7 @@ func (curl *CURL) Getinfo(info CurlInfo) (ret interface{}, err error) {
 		debugf("Getinfo %s", ret)
 		return ret, err
 	case C.CURLINFO_SLIST:
-		a_ptr_slist := new(_Ctype_struct_curl_slist)
+		a_ptr_slist := new(C.struct_curl_slist)
 		err := newCurlError(C.curl_easy_getinfo_slist(p, cInfo, &a_ptr_slist))
 		ret := []string{}
 		for a_ptr_slist != nil {


### PR DESCRIPTION
@andelf Please review this PR for Fixes #67 